### PR TITLE
Sort validated warc files in different directories.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,16 +183,17 @@
                                             <tag>${docker.tag}</tag>
                                         </tags>
                                         <optimise>true</optimise>
-                                        <runCmds>
-                                            <run>mkdir /validwarcs</run>
-                                        </runCmds>
                                         <volumes>
                                             <volume>/warcs</volume>
                                             <volume>/validwarcs</volume>
+                                            <volume>/invalidwarcs</volume>
+                                            <volume>/delivery</volume>
                                         </volumes>
                                         <env>
                                             <WARC_DIR>/warcs</WARC_DIR>
                                             <VALID_WARC_DIR>/validwarcs</VALID_WARC_DIR>
+                                            <INVALID_WARC_DIR>/invalidwarcs</INVALID_WARC_DIR>
+                                            <DELIVERY_WARC_DIR>/delivery</DELIVERY_WARC_DIR>
                                         </env>
                                         <cmd>
                                             <exec>

--- a/src/main/distfiles/config/application.conf
+++ b/src/main/distfiles/config/application.conf
@@ -2,9 +2,17 @@
 warcDir="/warcs";
 warcDir=${?WARC_DIR}
 
-# Where to move valid WARC files
-validWarcDir="/validwarcs"
+#Where to move Well-formed and valid WARC files
+validWarcDir="/validwarcs";
 validWarcDir=${?VALID_WARC_DIR}
+
+# Where to move invalid WARC files
+invalidWarcDir="/invalidwarcs"
+invalidWarcDir=${?INVALID_WARC_DIR}
+
+# Where to move valid WARC files for delivery
+deliveryWarcDir="/delivery"
+deliveryWarcDir=${?DELIVERY_WARC_DIR}
 
 # Path for Jhove configuration file
 jhoveConfigPath="/warcvalidator/config/jhove.conf"

--- a/src/main/java/no/nb/nna/veidemann/warcvalidator/model/WarcError.java
+++ b/src/main/java/no/nb/nna/veidemann/warcvalidator/model/WarcError.java
@@ -1,5 +1,6 @@
 package no.nb.nna.veidemann.warcvalidator.model;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -9,12 +10,15 @@ public class WarcError {
     private String status;
     private ArrayList<HashMap<String, String>> messages;
     private ArrayList<String> nonCompliantWarcIds;
+    private OffsetDateTime timestamp;
 
-    public WarcError(String filename, String status, ArrayList<HashMap<String, String>> messages, ArrayList<String> nonCompliantWarcIds) {
+    public WarcError(String filename, String status, ArrayList<HashMap<String, String>> messages,
+                     ArrayList<String> nonCompliantWarcIds, OffsetDateTime timestamp) {
         this.filename = filename;
         this.status = status;
         this.messages = messages;
         this.nonCompliantWarcIds = nonCompliantWarcIds;
+        this.timestamp = timestamp;
     }
 
     public String getFilename() {
@@ -49,4 +53,7 @@ public class WarcError {
         this.nonCompliantWarcIds = nonCompliantWarcId;
     }
 
+    public OffsetDateTime getTimestamp() { return timestamp; }
+
+    public void setTimestamp(OffsetDateTime timestamp) { this.timestamp = timestamp; }
 }

--- a/src/main/java/no/nb/nna/veidemann/warcvalidator/settings/Settings.java
+++ b/src/main/java/no/nb/nna/veidemann/warcvalidator/settings/Settings.java
@@ -15,7 +15,11 @@ public class Settings {
 
     private String warcDir;
 
+    private String deliveryWarcDir;
+
     private String validWarcDir;
+
+    private String invalidWarcDir;
 
     private String jhoveConfigPath;
 
@@ -45,9 +49,9 @@ public class Settings {
 
     public void setWarcDir(String warcDir) { this.warcDir = warcDir; }
 
-    public String getValidWarcDir() { return validWarcDir; }
+    public String getDeliveryWarcDir() { return deliveryWarcDir; }
 
-    public void setValidWarcDir(String validWarcDir) { this.validWarcDir = validWarcDir; }
+    public void setDeliveryWarcDir(String deliveryWarcDir) { this.deliveryWarcDir = deliveryWarcDir; }
 
     public String getJhoveConfigPath() {
         return jhoveConfigPath;
@@ -64,4 +68,12 @@ public class Settings {
     public void setSleepTime(int sleepTime) {
         this.sleepTime = sleepTime;
     }
+
+    public String getInvalidWarcDir() { return invalidWarcDir; }
+
+    public void setInvalidWarcDir(String invalidWarcDir) { this.invalidWarcDir = invalidWarcDir; }
+
+    public String getValidWarcDir() { return validWarcDir; }
+
+    public void setValidWarcDir(String validWarcDir) { this.validWarcDir = validWarcDir; }
 }


### PR DESCRIPTION
 - Use the directories /validwarcs, /invalidwarcs and /delivery to sort validated files based on result
- Include timestamp in DB insert
- Use NIO2 to handle moving and copying of files